### PR TITLE
Path fix and PHP7 compatibility

### DIFF
--- a/Text/LanguageDetect.php
+++ b/Text/LanguageDetect.php
@@ -211,7 +211,7 @@ class Text_LanguageDetect
 
         } elseif ($this->_data_dir != '@' . 'data_dir' . '@') {
             // if the data dir was set by the PEAR installer, use that
-            return $this->_data_dir . '/' . $fname;
+            return $this->_data_dir . '/Text_LanguageDetect/' . $fname;
 
         } else {
             // assume this was just unpacked somewhere

--- a/Text/LanguageDetect.php
+++ b/Text/LanguageDetect.php
@@ -211,7 +211,7 @@ class Text_LanguageDetect
 
         } elseif ($this->_data_dir != '@' . 'data_dir' . '@') {
             // if the data dir was set by the PEAR installer, use that
-            return $this->_data_dir . '/Text_LanguageDetect/' . $fname;
+            return $this->_data_dir . '/' . $fname;
 
         } else {
             // assume this was just unpacked somewhere

--- a/Text/LanguageDetect/Parser.php
+++ b/Text/LanguageDetect/Parser.php
@@ -102,7 +102,7 @@ class Text_LanguageDetect_Parser extends Text_LanguageDetect
      * @access  private
      * @param   string  $string     string to be parsed
      */
-    function Text_LanguageDetect_Parser($string) {
+    function __construct($string) {
         $this->_string = $string;
     }
 


### PR DESCRIPTION
I changed the constructor name in `Text_LanguageDetect_Parser` from the deprecated version to `__construct()`. Now Text_LanguageDetect runs flawlessly using PHP 7.0.0.

I needed to remove the extra `/Text_LanguageDetect` directory appended to `_data_dir` in `LanguageDetect.php` so the "data" directory could be found. Not entirely sure if this is the correct approach. Works on a fresh installation of Text_LanguageDetect (using composer).
