### PR TITLE
Fix non-existent path to data file with PEAR install

### DIFF
--- a/Text/LanguageDetect.php
+++ b/Text/LanguageDetect.php
@@ -196,7 +196,7 @@ class Text_LanguageDetect
 
         } elseif ($this->_data_dir != '@' . 'data_dir' . '@') {
             // if the data dir was set by the PEAR installer, use that
-            return $this->_data_dir . '/Text_LanguageDetect/' . $fname;
+            return $this->_data_dir . '/' . $fname;
 
         } else {
             // assume this was just unpacked somewhere


### PR DESCRIPTION
After a regular install with PEAR via Composer, the data file will be located in
 `/vendor/pear-pear.php.net/Text_LanguageDetect/data/lang.dat`
but LanguageDetect will try
`/vendor/pear-pear.php.net/Text_LanguageDetect/data/Text_LanguageDetect/lang.dat`
and fail.

There is no need to append `Text_LanguageDetect/` to the `data_dir` correctly set by PEAR.