### PR TITLE
Remove installation via PEAR from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,12 +8,6 @@ Returns confidence scores for each.
 Installation
 ============
 
-PEAR
-----
-::
-
-    $ pear install Text_LanguageDetect
-
 Composer
 --------
 ::


### PR DESCRIPTION
PEAR still wants to install v1.0.0, which doesn't work with modern versions of PHP (tested with PHP 8.1 on Ubuntu 22.04). Installing via composer works without issue.
Only describe the installation via composer.