### PR TITLE
Deprecated: Using null as an array offset is deprecated, use an empty…

### DIFF
--- a/Text/LanguageDetect.php
+++ b/Text/LanguageDetect.php
@@ -1655,7 +1655,7 @@ class Text_LanguageDetect
         }
 
         $newlang = array();
-        foreach ($lang as $key => $val) {            
+        foreach ($lang as $key => $val) {
             if ($convertKey) {
                 $newkey = Text_LanguageDetect_ISO639::$method($key);
                 $newlang[$newkey ?: ''] = $val;

--- a/Text/LanguageDetect.php
+++ b/Text/LanguageDetect.php
@@ -1655,12 +1655,12 @@ class Text_LanguageDetect
         }
 
         $newlang = array();
-        foreach ($lang as $key => $val) {
+        foreach ($lang as $key => $val) {            
             if ($convertKey) {
                 $newkey = Text_LanguageDetect_ISO639::$method($key);
-                $newlang[$newkey] = $val;
+                $newlang[$newkey ?: ''] = $val;
             } else {
-                $newlang[$key] = Text_LanguageDetect_ISO639::$method($val);
+                $newlang[$key ?: ''] = Text_LanguageDetect_ISO639::$method($val);
             }
         }
         return $newlang;


### PR DESCRIPTION
Deprecated: Using null as an array offset is deprecated, use an empty string instead at LanguageDetect.php:1661
Handle empty keys when converting language array.